### PR TITLE
sort similarities and indexes

### DIFF
--- a/R/CoreMethods.R
+++ b/R/CoreMethods.R
@@ -451,6 +451,8 @@ scmapCell2Cluster.SingleCellExperiment <- function(scmapCell_results, cluster_li
     labs_new <- character(ncol(cells))
     similarities_new <- numeric(ncol(cells))
     for (j in seq_len(ncol(cells))) {
+      similarities[, j] = sort(similarities[, j], decreasing = TRUE)
+      cells[, j] = cells[, j][sort(similarities[, j], decreasing = TRUE, index.return = TRUE)$ix]
       celltypes <- character(w)
       for (k in 1:w) {
         celltypes[k] <- cluster_list[[i]][cells[k, j]]


### PR DESCRIPTION
It's necessary to sort similarities and cell indexes before assigning cell type, since w for scmapCell2Cluster and w for scmapCell may be different.
(Now default w for scmapCell2Cluster is 3, while default w for scmapCell is 10.)